### PR TITLE
Implemented block UDPSenderReceiverFunctions

### DIFF
--- a/TestUDPSenderReceiver/UDPSenderReceiver.mo
+++ b/TestUDPSenderReceiver/UDPSenderReceiver.mo
@@ -40,7 +40,7 @@ model UDPSenderReceiver
     annotation (Placement(transformation(extent={{-16,-36},{4,-16}})));
   Modelica_DeviceDrivers.Blocks.Packaging.SerialPackager.GetInteger getInteger(
     n=nIntegerOut) if nIntegerOut > 0
-    annotation (Placement(transformation(extent={{14,-36},{34,-16}})));
+    annotation (Placement(transformation(extent={{14,-56},{34,-36}})));
 equation
   // UDP data exchange
   // Inputs
@@ -52,8 +52,6 @@ equation
   end if;
 
   if nRealIn == 0 and nRealIn > 0 then
-    connect(packager.pkgOut, addInteger.pkgIn) annotation (Line(
-      points={{-6,15.2},{-6,-15.2}}));
   end if;
 
   if nRealIn > 0 and nIntegerIn > 0 then
@@ -69,8 +67,6 @@ equation
   end if;
 
   if nIntegerIn == 0 and nRealIn > 0 then
-    connect(uDPSend.pkgIn, addReal.pkgOut[1])
-      annotation (Line(points={{-6,-41.2},{-6,-10.8}}, color={0,0,0}));
   end if;
 
   // Outputs
@@ -83,14 +79,13 @@ equation
 
   if nRealOut > 0 and nIntegerOut > 0 then
     connect(getReal.pkgOut[1], getInteger.pkgIn)
-      annotation (Line(points={{24,-10.8},{24,-15.2}}, color={0,0,0}));
+      annotation (Line(points={{24,-10.8},{24,-35.2}}, color={0,0,0}));
     connect(getInteger.y, yInteger)
-      annotation (Line(points={{35,-26},{90,-26}}, color={255,127,0}));
+      annotation (Line(points={{35,-46},{62,-46},{62,-26},{90,-26}},
+                                                   color={255,127,0}));
   end if;
 
   if nRealOut == 0 and nIntegerOut > 0 then
-    connect(uDPReceive.pkgOut,getInteger.pkgIn)
-      annotation (Line(points={{24,39.2},{24,-15.2}}));
   end if;
 
   if useReaTimFac == true then

--- a/TestUDPSenderReceiver/UDPSenderReceiverClocked.mo
+++ b/TestUDPSenderReceiver/UDPSenderReceiverClocked.mo
@@ -71,8 +71,6 @@ equation
   end if;
 
   if nRealIn == 0 and nRealIn > 0 then
-    connect(packager.pkgOut, addInteger.pkgIn) annotation (Line(
-      points={{-6,15.2},{-6,-15.2}}));
   end if;
 
   if nRealIn > 0 and nIntegerIn > 0 then
@@ -86,8 +84,6 @@ equation
   end if;
 
   if nIntegerIn == 0 and nRealIn > 0 then
-    connect(uDPSend.pkgIn, addReal.pkgOut[1])
-      annotation (Line(points={{-6,-41.2},{-6,-10.8}}, color={0,0,0}));
   end if;
 
   // Outputs
@@ -102,8 +98,6 @@ equation
   end if;
 
   if nRealOut == 0 and nIntegerOut > 0 then
-    connect(uDPReceive.pkgOut,getInteger.pkgIn) annotation (Line(
-      points={{24,39.2},{24,-15.2}}));
   end if;
 
   connect(sampleReal.y, addReal.u)

--- a/TestUDPSenderReceiver/UDPSenderReceiverFunctions.mo
+++ b/TestUDPSenderReceiver/UDPSenderReceiverFunctions.mo
@@ -2,7 +2,33 @@ within TestUDPSenderReceiver;
 model UDPSenderReceiverFunctions
   "Component for sending and receiving Real and Integer data over the UDP protocol"
   extends TestUDPSenderReceiver.UDPSenderReceiverGeneral;
+  import SI = Modelica.SIunits;
+  parameter SI.Period sampleTime = 0.1 "Sample period of component"
+    annotation(Dialog(group="Activation"));
+  parameter SI.Time startTime = 0 "First sample time instant"
+    annotation(Dialog(group="Activation"));
+  final parameter Integer recvBufferSize = nRealOut*8 + nIntegerOut*4;
+  final parameter Integer sendBufferSize = nRealIn*8 + nIntegerIn*4;
+  Modelica_DeviceDrivers.Communication.UDPSocket udprecv = Modelica_DeviceDrivers.Communication.UDPSocket(port_recv, recvBufferSize, true);
+  Modelica_DeviceDrivers.Packaging.SerialPackager pkgrecv = Modelica_DeviceDrivers.Packaging.SerialPackager(recvBufferSize);
+  Modelica_DeviceDrivers.Communication.UDPSocket udpsend = Modelica_DeviceDrivers.Communication.UDPSocket(0,0);
+  Modelica_DeviceDrivers.Packaging.SerialPackager pkgsend = Modelica_DeviceDrivers.Packaging.SerialPackager(sendBufferSize);
 
+  output Integer nRecvBytes(start=0,fixed=true);
+  output Integer nRecvbufOverwrites(start=0,fixed=true);
+protected
+  parameter  Modelica_DeviceDrivers.Utilities.Types.ByteOrder byteOrder = Modelica_DeviceDrivers.Utilities.Types.ByteOrder.LE;
+algorithm
+  when sample(startTime,sampleTime) then
+    (nRecvBytes,nRecvbufOverwrites) := Modelica_DeviceDrivers.Communication.UDPSocket_.read(udprecv, pkgrecv);
+    yReal := Modelica_DeviceDrivers.Packaging.SerialPackager_.getReal(pkgrecv, nRealOut, byteOrder);
+    yInteger := Modelica_DeviceDrivers.Packaging.SerialPackager_.getInteger(pkgrecv, nIntegerOut, byteOrder);
+
+    Modelica_DeviceDrivers.Packaging.SerialPackager_.clear(pkgsend);
+    Modelica_DeviceDrivers.Packaging.SerialPackager_.addReal(pkgsend,uReal,byteOrder);
+    Modelica_DeviceDrivers.Packaging.SerialPackager_.addInteger(pkgsend,uInteger,byteOrder);
+    Modelica_DeviceDrivers.Communication.UDPSocket_.sendTo(udpsend, IPAddress, port_send, pkgsend, sendBufferSize);
+  end when;
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-80,-80},{80,80}},  initialScale=0.1)),
     Icon(coordinateSystem(preserveAspectRatio=false,extent={{-80,-80},{80,80}}, initialScale=0.1),graphics={
     Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,0}),


### PR DESCRIPTION
Add the necessary functions to the interface block UDPSenderReceiverFunctions. I didn't do much testing, just let me know if it doesn't work.

I also cleaned up the block-based packaging models since there were too many connections and I'm surprised that this worked with that superfluous connections. It was not intended that one could have several connections to one `pkgIn` connector
